### PR TITLE
Upgrade to latest karma-jasmine

### DIFF
--- a/coverage-jasmine/package.json
+++ b/coverage-jasmine/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "karma": "latest",
-    "karma-jasmine": "~0.1.0",
+    "karma-jasmine": "latest",
     "karma-firefox-launcher": "latest",
     "karma-coverage": "latest"
   }

--- a/jasmine_2/package.json
+++ b/jasmine_2/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "karma": "latest",
-    "karma-jasmine": "~0.2.0",
+    "karma-jasmine": "latest",
     "karma-firefox-launcher": "latest"
   }
 }

--- a/requirejs/package.json
+++ b/requirejs/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "karma": "^0.12.2",
     "karma-firefox-launcher": "latest",
-    "karma-jasmine": "~0.1.0",
+    "karma-jasmine": "latest",
     "karma-requirejs": "^0.2.1",
     "requirejs": "^2.1.11"
   }

--- a/saucelabs/package.json
+++ b/saucelabs/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "karma": "latest",
-    "karma-jasmine": "~0.1.0",
+    "karma-jasmine": "latest",
     "karma-firefox-launcher": "latest",
     "karma-sauce-launcher": "latest"
   }


### PR DESCRIPTION
Needed for https://github.com/karma-runner/karma/pull/1404 to fix the integration tests.

This upgrades

* coverage-jasmine
* jasmine_2
* requirejs
* saucelabs

to always use the latest version of karma-jasmine. Only jasmine still uses the `0.1` branch to test that compatibility.  