### PR TITLE
chore: switch to headless browsers when running tests

### DIFF
--- a/coffee/karma.conf.coffee
+++ b/coffee/karma.conf.coffee
@@ -6,7 +6,7 @@ module.exports = (config) ->
       '*.coffee'
     ]
 
-    browsers: ['Firefox']
+    browsers: ['FirefoxHeadless']
 
     coffeePreprocessor:
       options:

--- a/coverage-coffee/karma.conf.coffee
+++ b/coverage-coffee/karma.conf.coffee
@@ -6,7 +6,7 @@ module.exports = (config) ->
       '*.coffee'
     ]
 
-    browsers: ['Firefox']
+    browsers: ['FirefoxHeadless']
 
     coffeePreprocessor:
       options:

--- a/coverage-jasmine/karma.conf.js
+++ b/coverage-jasmine/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function(config) {
       'test/*.js'
     ],
 
-    browsers: ['Firefox'],
+    browsers: ['FirefoxHeadless'],
 
     reporters: ['dots', 'coverage'],
 

--- a/coverage-mocha-requirejs/karma.conf.js
+++ b/coverage-mocha-requirejs/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function(config) {
       {pattern: '*.js', included: false},
     ],
 
-    browsers: ['Firefox'],
+    browsers: ['FirefoxHeadless'],
 
     reporters: ['dots', 'coverage'],
 

--- a/coverage-qunit/karma.conf.js
+++ b/coverage-qunit/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function(config) {
       'test/*.js'
     ],
 
-    browsers: ['Firefox'],
+    browsers: ['FirefoxHeadless'],
 
     reporters: ['dots', 'coverage'],
 

--- a/dojo/karma.conf.js
+++ b/dojo/karma.conf.js
@@ -10,6 +10,6 @@ module.exports = function(config) {
 
     reporters: ['dots'],
 
-    browsers: ['Firefox']
+    browsers: ['FirefoxHeadless']
   });
 };

--- a/googmodule/karma.conf.js
+++ b/googmodule/karma.conf.js
@@ -8,6 +8,6 @@ module.exports = function(config) {
       '*.spec.js'
     ],
     plugins: ['karma-jasmine', 'karma-firefox-launcher', 'karma-googmodule-preprocessor'],
-    browsers: ['Firefox'],
+    browsers: ['FirefoxHeadless'],
   });
 };

--- a/html2js/karma.conf.js
+++ b/html2js/karma.conf.js
@@ -11,7 +11,7 @@ module.exports = function(config) {
       '*.html': ['html2js']
     },
 
-    browsers: ['Firefox'],
+    browsers: ['FirefoxHeadless'],
 
     reporters: ['dots']
   });

--- a/jasmine/karma.conf.js
+++ b/jasmine/karma.conf.js
@@ -6,6 +6,6 @@ module.exports = function(config) {
       '*.js'
     ],
 
-    browsers: ['Firefox']
+    browsers: ['FirefoxHeadless']
   });
 };

--- a/junit/karma.conf.js
+++ b/junit/karma.conf.js
@@ -6,7 +6,7 @@ module.exports = function(config) {
       '*.js'
     ],
 
-    browsers: ['Firefox'],
+    browsers: ['FirefoxHeadless'],
 
     reporters: ['dots', 'junit'],
 

--- a/mocha/karma.conf.js
+++ b/mocha/karma.conf.js
@@ -6,7 +6,7 @@ module.exports = function(config) {
       '*.js'
     ],
 
-    browsers: ['Firefox'],
+    browsers: ['FirefoxHeadless'],
 
     reporters: ['dots']
   });

--- a/qunit/karma.conf.js
+++ b/qunit/karma.conf.js
@@ -6,7 +6,7 @@ module.exports = function(config) {
       '*.js'
     ],
 
-    browsers: ['Firefox'],
+    browsers: ['FirefoxHeadless'],
 
     reporters: ['dots']
   });

--- a/requirejs/karma.conf.js
+++ b/requirejs/karma.conf.js
@@ -13,6 +13,6 @@ module.exports = function(config) {
 
     reporters: ['dots'],
 
-    browsers: ['Firefox']
+    browsers: ['FirefoxHeadless']
   });
 };

--- a/saucelabs/karma.conf.js
+++ b/saucelabs/karma.conf.js
@@ -1,4 +1,8 @@
-var TRAVIS_WITH_SAUCE = !!process.env.SAUCE_ACCESS_KEY;
+// When running pre-release tests we want tests to fail if SauceLabs is not
+// configured instead of falling back to the headless browser. That's what
+// KARMA_TEST_NO_FALLBACK variable controls.
+const useSauceLabs = process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY
+  || process.env.KARMA_TEST_NO_FALLBACK
 
 module.exports = function(config) {
   config.set({
@@ -8,7 +12,7 @@ module.exports = function(config) {
       '*.js'
     ],
 
-    browsers: [TRAVIS_WITH_SAUCE ? 'sl_chrome_linux' : 'Firefox'],
+    browsers: [useSauceLabs ? 'sl_chrome_linux' : 'FirefoxHeadless'],
 
     reporters: ['dots'],
 


### PR DESCRIPTION
I've intentionally not replaced Travis in this repository as I think it will be better to move the integration tests code to the `karma` repository and maintain them there to make them more discoverable and easier to update. I plan to do this in the follow-up PR.