### PR TITLE
Enable SauceLabs Tests in Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   linux:
+    env:
+      SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
     name: "Node ${{ matrix.node }} on Linux: Test"
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Do not allow testing to fallback to `FirefoxHeadless` when running in GitHub Actions. Also, read the SauceLabs credentials from the secrets.